### PR TITLE
Update groovy, release last Java 8 CH 3.3.4 version, update to CH 3.3.5-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
+# Generated files (maven).
 target/
+.checkstyle
 true
+
+# Eclipse setup.
+.classpath
+.project
+.settings/
+
+# Intellij setup.
 .idea/
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,9 @@
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-all</artifactId>
-			<version>2.1.1</version>
+			<artifactId>groovy</artifactId>
+			<version>3.0.8</version>
+			<type>jar</type>
 		</dependency>
 	</dependencies>
 	<build>
@@ -208,12 +209,12 @@
 							<shadedClassifierName>Bundle</shadedClassifierName>
 							<artifactSet>
 								<includes>
-									<include>org.codehaus.groovy:groovy-all:jar:*</include>
+									<include>org.codehaus.groovy:groovy:jar:*</include>
 								</includes>
 							</artifactSet>
 							<filters>
 								<filter>
-									<artifact>org.codehaus.groovy:groovy-all:jar:*</artifact>
+									<artifact>org.codehaus.groovy:groovy:jar:*</artifact>
 									<includes>
 										<include>**</include>
 									</includes>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
+				<configuration>
+					<showDeprecation>true</showDeprecation>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
 			</plugin>
 
 			<!-- JAR creation plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<license>
 			<name>The MIT License</name>
 			<url>LICENSE.txt</url>
-			<distribution>repo</distribution>            
+			<distribution>repo</distribution>
 		</license>
 	</licenses>
 	<scm>
@@ -45,7 +45,7 @@
 			<id>sk89q-repo</id>
 			<url>http://maven.sk89q.com/repo</url>
 		</repository>
-    
+
 		<!-- Other repositories -->
 		<repository>
 			<id>maven-central</id>
@@ -93,33 +93,33 @@
 				<groupId>org.bsc.maven</groupId>
 				<artifactId>maven-processor-plugin</artifactId>
 				<version>2.2.4</version>
- 
+
 				<executions>
 					<execution>
 						<id>process</id>
 						<phase>process-classes</phase>
- 
+
 						<goals>
 							<goal>process</goal>
 						</goals>
 					</execution>
 				</executions>
- 
+
 				<configuration>
 					<outputDirectory>src/main/generated</outputDirectory>
- 
+
 					<processors>
 						<processor>com.laytonsmith.core.extensions.ExtensionAnnotationProcessor</processor>
 					</processors>
 				</configuration>
 			</plugin>
- 
+
 			<!-- Leave this alone! Run-time extension loading speedup. -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
 				<version>1.2.1</version>
- 
+
 				<executions>
 					<execution>
 						<id>cache-annotations</id>
@@ -129,10 +129,10 @@
 						</goals>
 					</execution>
 				</executions>
- 
+
 				<configuration>
 					<mainClass>com.laytonsmith.PureUtilities.ClassLoading.Annotations.CacheAnnotations</mainClass>
- 
+
 					<arguments>
 						<argument>${basedir}/target/classes</argument>
 						<argument>${basedir}/target/classes</argument>
@@ -185,7 +185,7 @@
 					<goals>assembly:assembly</goals>
 				</configuration>
 			</plugin>
-            
+
 			<!-- Shade plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -218,7 +218,7 @@
 					</execution>
 				</executions>
 			</plugin>
-            
+
 			<!-- Getting rid of maven warnings by providing versions for the following plugins -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -253,7 +253,7 @@
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<version>2.4</version>
 			</plugin>
-      
+
 			<!-- Site / report generation -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.chgroovy</groupId>
 	<artifactId>chgroovy</artifactId>
-	<version>1.0.3-SNAPSHOT</version>
+	<version>1.0.3</version>
 	<name>CHGroovy</name>
 	<description>Unlocks the full potential of your server, at runtime by adding a way to run groovy scripts from in game, or elsewhere.</description>
 	<inceptionYear>2013</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.chgroovy</groupId>
 	<artifactId>chgroovy</artifactId>
-	<version>1.0.3</version>
+	<version>1.0.4-SNAPSHOT</version>
 	<name>CHGroovy</name>
 	<description>Unlocks the full potential of your server, at runtime by adding a way to run groovy scripts from in game, or elsewhere.</description>
 	<inceptionYear>2013</inceptionYear>
@@ -57,7 +57,9 @@
 		<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>commandhelper</artifactId>
-			<version>3.3.4-SNAPSHOT</version>
+			<version>3.3.5-SNAPSHOT</version>
+			<type>jar</type>
+			<classifier>full</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
@@ -93,7 +95,7 @@
 			<plugin>
 				<groupId>org.bsc.maven</groupId>
 				<artifactId>maven-processor-plugin</artifactId>
-				<version>2.2.4</version>
+				<version>4.5</version>
 
 				<executions>
 					<execution>
@@ -119,7 +121,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.2.1</version>
+				<version>3.0.0</version>
 
 				<executions>
 					<execution>
@@ -144,11 +146,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.8.1</version>
 				<configuration>
 					<showDeprecation>true</showDeprecation>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>16</source>
+					<target>16</target>
 				</configuration>
 			</plugin>
 
@@ -156,7 +158,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.1</version>
+				<version>3.2.0</version>
 				<configuration>
 					<archive>
 						<addMavenDescriptor>true</addMavenDescriptor>

--- a/src/main/java/com/chgroovy/core/CHGroovy.java
+++ b/src/main/java/com/chgroovy/core/CHGroovy.java
@@ -12,6 +12,6 @@ public class CHGroovy extends AbstractExtension {
 
 	@Override
 	public Version getVersion() {
-		return new SimpleVersion(1, 0, 3, "SNAPSHOT");
+		return new SimpleVersion(1, 0, 3);
 	}
 }

--- a/src/main/java/com/chgroovy/core/CHGroovy.java
+++ b/src/main/java/com/chgroovy/core/CHGroovy.java
@@ -10,6 +10,7 @@ import com.laytonsmith.core.extensions.AbstractExtension;
  */
 public class CHGroovy extends AbstractExtension {
 
+	@Override
 	public Version getVersion() {
 		return new SimpleVersion(1, 0, 3, "SNAPSHOT");
 	}

--- a/src/main/java/com/chgroovy/core/CHGroovy.java
+++ b/src/main/java/com/chgroovy/core/CHGroovy.java
@@ -12,6 +12,6 @@ public class CHGroovy extends AbstractExtension {
 
 	@Override
 	public Version getVersion() {
-		return new SimpleVersion(1, 0, 3);
+		return new SimpleVersion(1, 0, 4, "SNAPSHOT");
 	}
 }

--- a/src/main/java/com/chgroovy/core/CHGroovy.java
+++ b/src/main/java/com/chgroovy/core/CHGroovy.java
@@ -6,12 +6,11 @@ import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.core.extensions.AbstractExtension;
 
 /**
- *
+ * CHGroovy extension main class.
  */
 public class CHGroovy extends AbstractExtension {
 
 	public Version getVersion() {
 		return new SimpleVersion(1, 0, 3, "SNAPSHOT");
 	}
-
 }

--- a/src/main/java/com/chgroovy/core/Functions.java
+++ b/src/main/java/com/chgroovy/core/Functions.java
@@ -9,6 +9,7 @@ import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
 import com.laytonsmith.core.exceptions.CRE.CREPluginInternalException;
+import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.functions.AbstractFunction;
 import com.laytonsmith.core.natives.interfaces.Mixed;
@@ -23,20 +24,25 @@ public class Functions {
 	@api
 	public static class groovy extends AbstractFunction {
 
-		public Class[] thrown() {
+		@SuppressWarnings("unchecked")
+		@Override
+		public Class<? extends CREThrowable>[] thrown() {
 			return new Class[]{
 				CREPluginInternalException.class
 			};
 		}
 
+		@Override
 		public boolean isRestricted() {
 			return true;
 		}
 
+		@Override
 		public Boolean runAsync() {
 			return null;
 		}
 
+		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
 			String script = args[0].val();
 			CArray env = new CArray(t);
@@ -65,14 +71,17 @@ public class Functions {
 			return ret;
 		}
 
+		@Override
 		public String getName() {
 			return "groovy";
 		}
 
+		@Override
 		public Integer[] numArgs() {
 			return new Integer[]{1, 2, 3};
 		}
 
+		@Override
 		public String docs() {
 			return "array {script, environment, toReturn} Runs a groovy script. The script can set variables beforehand with the environment"
 					+ " variable, which should be an associative array mapping variable names to values. Arrays are not directly supported,"
@@ -80,6 +89,7 @@ public class Functions {
 					+ " to toReturn, which will cause those values to be returned as a part of the associative array returned.";
 		}
 
+		@Override
 		public Version since() {
 			return MSVersion.V3_3_1;
 		}

--- a/src/main/java/com/chgroovy/core/Functions.java
+++ b/src/main/java/com/chgroovy/core/Functions.java
@@ -20,69 +20,69 @@ import groovy.lang.GroovyShell;
  */
 public class Functions {
 
-    @api
-    public static class groovy extends AbstractFunction{
+	@api
+	public static class groovy extends AbstractFunction{
 
-        public Class[] thrown() {
-            return new Class[]{
+		public Class[] thrown() {
+			return new Class[]{
 				CREPluginInternalException.class
-            };
-        }
+			};
+		}
 
-        public boolean isRestricted() {
-            return true;
-        }
+		public boolean isRestricted() {
+			return true;
+		}
 
-        public Boolean runAsync() {
-            return null;
-        }
+		public Boolean runAsync() {
+			return null;
+		}
 
-        public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-            String script = args[0].val();
-            CArray env = new CArray(t);
-            CArray toReturn = new CArray(t);
-            if(args.length > 1){
-                env = Static.getArray(args[1], t);
-            }
-            if(args.length > 2){
-                toReturn = Static.getArray(args[2], t);
-            }
-            Binding binding = new Binding();
-            try{
-                for(String key : env.stringKeySet()){
-                    binding.setVariable(key, Construct.GetPOJO(env.get(key, t)));
-                }
-                GroovyShell shell = new GroovyShell(binding);
-                shell.evaluate(script);
-            } catch(Exception ex){
-                throw new CREPluginInternalException(ex.getMessage(), t);
-            }
-            CArray ret = CArray.GetAssociativeArray(t);
-            for(String key : toReturn.stringKeySet()){
-                Object var = binding.getVariable(toReturn.get(key, t).val());
-                ret.set(toReturn.get(key, t).val(), Construct.GetConstruct(var), t);
-            }
-            return ret;
-        }
+		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
+			String script = args[0].val();
+			CArray env = new CArray(t);
+			CArray toReturn = new CArray(t);
+			if(args.length > 1){
+				env = Static.getArray(args[1], t);
+			}
+			if(args.length > 2){
+				toReturn = Static.getArray(args[2], t);
+			}
+			Binding binding = new Binding();
+			try{
+				for(String key : env.stringKeySet()){
+					binding.setVariable(key, Construct.GetPOJO(env.get(key, t)));
+				}
+				GroovyShell shell = new GroovyShell(binding);
+				shell.evaluate(script);
+			} catch(Exception ex){
+				throw new CREPluginInternalException(ex.getMessage(), t);
+			}
+			CArray ret = CArray.GetAssociativeArray(t);
+			for(String key : toReturn.stringKeySet()){
+				Object var = binding.getVariable(toReturn.get(key, t).val());
+				ret.set(toReturn.get(key, t).val(), Construct.GetConstruct(var), t);
+			}
+			return ret;
+		}
 
-        public String getName() {
-            return "groovy";
-        }
+		public String getName() {
+			return "groovy";
+		}
 
-        public Integer[] numArgs() {
-            return new Integer[]{1, 2, 3};
-        }
+		public Integer[] numArgs() {
+			return new Integer[]{1, 2, 3};
+		}
 
-        public String docs() {
-            return "array {script, environment, toReturn} Runs a groovy script. The script can set variables beforehand with the environment"
-                    + " variable, which should be an associative array mapping variable names to values. Arrays are not directly supported,"
-                    + " as everything is simply passed in as a string. Values can be returned from the script, by giving a list of named values"
-                    + " to toReturn, which will cause those values to be returned as a part of the associative array returned.";
-        }
+		public String docs() {
+			return "array {script, environment, toReturn} Runs a groovy script. The script can set variables beforehand with the environment"
+					+ " variable, which should be an associative array mapping variable names to values. Arrays are not directly supported,"
+					+ " as everything is simply passed in as a string. Values can be returned from the script, by giving a list of named values"
+					+ " to toReturn, which will cause those values to be returned as a part of the associative array returned.";
+		}
 
-        public Version since() {
-            return MSVersion.V3_3_1;
-        }
+		public Version since() {
+			return MSVersion.V3_3_1;
+		}
 
-    }
+	}
 }

--- a/src/main/java/com/chgroovy/core/Functions.java
+++ b/src/main/java/com/chgroovy/core/Functions.java
@@ -21,7 +21,7 @@ import groovy.lang.GroovyShell;
 public class Functions {
 
 	@api
-	public static class groovy extends AbstractFunction{
+	public static class groovy extends AbstractFunction {
 
 		public Class[] thrown() {
 			return new Class[]{
@@ -83,6 +83,5 @@ public class Functions {
 		public Version since() {
 			return MSVersion.V3_3_1;
 		}
-
 	}
 }

--- a/src/main/java/com/chgroovy/core/Functions.java
+++ b/src/main/java/com/chgroovy/core/Functions.java
@@ -2,8 +2,8 @@ package com.chgroovy.core;
 
 import com.laytonsmith.PureUtilities.Version;
 import com.laytonsmith.annotations.api;
+import com.laytonsmith.core.ArgumentValidation;
 import com.laytonsmith.core.MSVersion;
-import com.laytonsmith.core.Static;
 import com.laytonsmith.core.constructs.CArray;
 import com.laytonsmith.core.constructs.Construct;
 import com.laytonsmith.core.constructs.Target;
@@ -42,10 +42,10 @@ public class Functions {
 			CArray env = new CArray(t);
 			CArray toReturn = new CArray(t);
 			if(args.length > 1){
-				env = Static.getArray(args[1], t);
+				env = ArgumentValidation.getArray(args[1], t);
 			}
 			if(args.length > 2){
-				toReturn = Static.getArray(args[2], t);
+				toReturn = ArgumentValidation.getArray(args[2], t);
 			}
 			Binding binding = new Binding();
 			try{


### PR DESCRIPTION
There is a clear commit to create a release for, allowing CommandHelper 3.3.4 users to make use of the groovy update as well.