### PR TITLE
Update dependencies and fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 		<developer>
 			<id>ladycailin</id>
 			<name>LadyCailin</name>
-			<url>http://www.laytonsmith.com#donations</url>
-			<organizationUrl>http://www.laytonsmith.com</organizationUrl>
+			<url>https://www.laytonsmith.com#donations</url>
+			<organizationUrl>https://www.laytonsmith.com</organizationUrl>
 			<roles>
 				<role>project manager</role>
 				<role>developer</role>
@@ -32,24 +32,18 @@
 		</license>
 	</licenses>
 	<scm>
-		<connection>scm:git:git://github.com/wraithguard01/chgroovy.git</connection>
-		<url>https://github.com/wraithguard01/chgroovy</url>
-		<developerConnection>scm:git:git@github.com:sk89q/chgroovy.git</developerConnection>
+		<connection>scm:git:git://github.com/LadyCailin/chgroovy.git</connection>
+		<url>https://github.com/LadyCailin/chgroovy</url>
+		<developerConnection>scm:git:git@github.com:LadyCailin/chgroovy.git</developerConnection>
 	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<repositories>
-		<!-- Repository for other dependencies of SK's -->
-		<repository>
-			<id>sk89q-repo</id>
-			<url>http://maven.sk89q.com/repo</url>
-		</repository>
-
 		<!-- Other repositories -->
 		<repository>
 			<id>maven-central</id>
-			<url>http://repo1.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 		</repository>
 	</repositories>
 	<dependencies>
@@ -64,7 +58,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy</artifactId>
-			<version>3.0.8</version>
+			<version>3.0.20</version>
 			<type>jar</type>
 		</dependency>
 	</dependencies>
@@ -95,7 +89,7 @@
 			<plugin>
 				<groupId>org.bsc.maven</groupId>
 				<artifactId>maven-processor-plugin</artifactId>
-				<version>4.5</version>
+				<version>5.0-jdk8-rc1</version>
 
 				<executions>
 					<execution>
@@ -149,8 +143,7 @@
 				<version>3.8.1</version>
 				<configuration>
 					<showDeprecation>true</showDeprecation>
-					<source>16</source>
-					<target>16</target>
+					<release>16</release>
 				</configuration>
 			</plugin>
 
@@ -162,14 +155,10 @@
 				<configuration>
 					<archive>
 						<addMavenDescriptor>true</addMavenDescriptor>
-						<pomPropertiesFile>true</pomPropertiesFile>
 						<manifest>
 							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 						</manifest>
-						<manifestEntries>
-							<Class-Path></Class-Path>
-						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>
@@ -187,7 +176,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.2.2</version>
+				<version>3.0.0-M4</version>
 				<configuration>
 					<preparationGoals>assembly:assembly</preparationGoals>
 					<goals>assembly:assembly</goals>
@@ -198,7 +187,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>1.4</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>ShadedBundle</id>
@@ -231,17 +220,17 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.3.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.0.0-M1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
+				<version>3.2.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -259,41 +248,14 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.7</version>
 			</plugin>
 
 			<!-- Site / report generation -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<reportPlugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-project-info-reports-plugin</artifactId>
-							<version>2.5</version>
-							<reportSets>
-								<reportSet>
-									<reports>
-										<report>license</report>
-										<report>index</report>
-									</reports>
-								</reportSet>
-							</reportSets>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>2.8.1</version>
-						</plugin>
-						<plugin>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>cobertura-maven-plugin</artifactId>
-							<version>2.4</version>
-						</plugin>
-					</reportPlugins>
-				</configuration>
+				<version>3.9.1</version>
 			</plugin>
 		</plugins>
 	</build>
@@ -314,4 +276,31 @@
 			</build>
 		</profile>
 	</profiles>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-project-info-reports-plugin</artifactId>
+				<version>3.1.2</version>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>license</report>
+							<report>index</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.4</version>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>


### PR DESCRIPTION
The pomPropertiesFile was what was breaking the build, but I updated a number of other things including: matching dependencies to at least what is used by CommandHelper, updating out-dated links, and fixing the release Java version.

Feel free to pull or use this as reference for making your own changes.